### PR TITLE
Peer, LocalSession, LocalCoordinator lifecycle fixes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -936,8 +936,9 @@ dependencies = [
 
 [[package]]
 name = "interceptor"
-version = "0.7.7"
-source = "git+https://github.com/webrtc-rs/webrtc?branch=master#45e66fc3a9e3a66cf7584e018ced6512621f86c5"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5227f64c1b6aa2262b3e6433b75b22e587298cc3edece3ffd8ac86ca180680b8"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1431,8 +1432,9 @@ dependencies = [
 
 [[package]]
 name = "rtcp"
-version = "0.6.6"
-source = "git+https://github.com/webrtc-rs/webrtc?branch=master#45e66fc3a9e3a66cf7584e018ced6512621f86c5"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70fd6d59c624d6f774b23569d57d255fd0eee3323e6df797d6d606989e8c038e"
 dependencies = [
  "bytes",
  "thiserror",
@@ -1441,8 +1443,9 @@ dependencies = [
 
 [[package]]
 name = "rtp"
-version = "0.6.6"
-source = "git+https://github.com/webrtc-rs/webrtc?branch=master#45e66fc3a9e3a66cf7584e018ced6512621f86c5"
+version = "0.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68ecd5b57967801ff3616239508be0ecc50c6a10a9ca0716475002bf9dc44210"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1497,8 +1500,9 @@ dependencies = [
 
 [[package]]
 name = "sdp"
-version = "0.5.1"
-source = "git+https://github.com/webrtc-rs/webrtc?branch=master#45e66fc3a9e3a66cf7584e018ced6512621f86c5"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8747d0c2d59cc81b25859ec4cd9aaabda5551d02a49fb5976f34c74825e1533f"
 dependencies = [
  "rand",
  "substring",
@@ -1673,8 +1677,9 @@ checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "stun"
-version = "0.4.2"
-source = "git+https://github.com/webrtc-rs/webrtc?branch=master#45e66fc3a9e3a66cf7584e018ced6512621f86c5"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d87f7ba21ed969d81d51eae81c5b3ded1aadf5d6aa341a24524f767583f9c5c"
 dependencies = [
  "base64",
  "crc",
@@ -1791,9 +1796,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.14"
+version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c3f9a28b618c3a6b9251b6908e9c99e04b9e5c02e6581ccbb67d59c34ef7f9b"
+checksum = "db76ff9fa4b1458b3c7f077f3ff9887394058460d21e634355b273aaf11eea45"
 dependencies = [
  "itoa",
  "libc",
@@ -1975,8 +1980,9 @@ dependencies = [
 
 [[package]]
 name = "turn"
-version = "0.5.4"
-source = "git+https://github.com/webrtc-rs/webrtc?branch=master#45e66fc3a9e3a66cf7584e018ced6512621f86c5"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cebac31acf8401a435c48ccdde7ca8e1b82e80d5ec2d428ece0e7fa774a9a566"
 dependencies = [
  "async-trait",
  "base64",
@@ -2181,8 +2187,9 @@ dependencies = [
 
 [[package]]
 name = "webrtc"
-version = "0.4.0"
-source = "git+https://github.com/webrtc-rs/webrtc?branch=master#45e66fc3a9e3a66cf7584e018ced6512621f86c5"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86c209d48c93a9614ff6b068aef3b8b52fb4be7b1663394a904a03633c3768f2"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2220,8 +2227,9 @@ dependencies = [
 
 [[package]]
 name = "webrtc-data"
-version = "0.4.0"
-source = "git+https://github.com/webrtc-rs/webrtc?branch=master#45e66fc3a9e3a66cf7584e018ced6512621f86c5"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47dee5d6b9ad569637cd7b383ac8949c65a92540c990dcac0c2046d7b573fdcf"
 dependencies = [
  "bytes",
  "derive_builder",
@@ -2234,8 +2242,9 @@ dependencies = [
 
 [[package]]
 name = "webrtc-dtls"
-version = "0.5.4"
-source = "git+https://github.com/webrtc-rs/webrtc?branch=master#45e66fc3a9e3a66cf7584e018ced6512621f86c5"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a132d8644d0c39d0b631f4bec0996a5fc9ffc27d17cbe7e63b66c264c8faa51b"
 dependencies = [
  "aes 0.6.0",
  "aes-gcm 0.8.0",
@@ -2274,8 +2283,9 @@ dependencies = [
 
 [[package]]
 name = "webrtc-ice"
-version = "0.7.1"
-source = "git+https://github.com/webrtc-rs/webrtc?branch=master#45e66fc3a9e3a66cf7584e018ced6512621f86c5"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "496e3d20795fd44f8b3137e830e5cb66fc86b6df309429e2a0fbbfd168213595"
 dependencies = [
  "async-trait",
  "crc",
@@ -2296,8 +2306,9 @@ dependencies = [
 
 [[package]]
 name = "webrtc-mdns"
-version = "0.4.3"
-source = "git+https://github.com/webrtc-rs/webrtc?branch=master#45e66fc3a9e3a66cf7584e018ced6512621f86c5"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "164bc5ee3eb3e37ba3aae7f20c161dad369f5c456383df254c13ba5c381c7307"
 dependencies = [
  "log",
  "socket2",
@@ -2308,8 +2319,9 @@ dependencies = [
 
 [[package]]
 name = "webrtc-media"
-version = "0.4.6"
-source = "git+https://github.com/webrtc-rs/webrtc?branch=master#45e66fc3a9e3a66cf7584e018ced6512621f86c5"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "111dabe8e4db0c155634c2020aa2a5c7363c3fea3df700c7c03294e5ea22cd5c"
 dependencies = [
  "byteorder",
  "bytes",
@@ -2323,8 +2335,9 @@ dependencies = [
 
 [[package]]
 name = "webrtc-sctp"
-version = "0.6.0"
-source = "git+https://github.com/webrtc-rs/webrtc?branch=master#45e66fc3a9e3a66cf7584e018ced6512621f86c5"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48e0817aa891415923f7b0a0f40e1d77193652b7eb74209e7413c58eefe20382"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2338,8 +2351,9 @@ dependencies = [
 
 [[package]]
 name = "webrtc-srtp"
-version = "0.8.9"
-source = "git+https://github.com/webrtc-rs/webrtc?branch=master#45e66fc3a9e3a66cf7584e018ced6512621f86c5"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40f3f827244a194425bd30cbccf0bb35ed24c9c40b1b96516faaf85713d9bdab"
 dependencies = [
  "aead 0.4.3",
  "aes 0.7.5",
@@ -2361,8 +2375,9 @@ dependencies = [
 
 [[package]]
 name = "webrtc-util"
-version = "0.5.4"
-source = "git+https://github.com/webrtc-rs/webrtc?branch=master#45e66fc3a9e3a66cf7584e018ced6512621f86c5"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4921b6a976b5570004e9c1b29ae109a81a73e2370e80627efa315f9ad0105f43"
 dependencies = [
  "async-trait",
  "bitflags",

--- a/examples/pubsubtest/main.js
+++ b/examples/pubsubtest/main.js
@@ -3,7 +3,7 @@ const remotesDiv = document.getElementById("remotes");
 
 const params = new URLSearchParams(window.location.search)
 
-const serverUrl = `ws://${(window.location.host) || "localhost"}:7000/session/test`;
+const serverUrl = `ws://${(window.location.host) || "localhost"}:7000/session/d205be62-ff33-4608-93a1-957404cdaed3`;
 
 /* eslint-env browser */
 const joinBtns = document.getElementById("start-btns");
@@ -19,7 +19,7 @@ const config = {
 const signalLocal = new Signal.IonSFUJSONRPCSignal(serverUrl);
 
 const clientLocal = new IonSDK.Client(signalLocal, config);
-signalLocal.onopen = () => clientLocal.join(params.has("session") ? params.get("session") : "test session");
+signalLocal.onopen = () => clientLocal.join(params.has("session") ? params.get("session") : "d205be62-ff33-4608-93a1-957404cdaed3");
 
 /**
  * For every remote stream this object will hold the follwing information:

--- a/switchboard-sfu/Cargo.toml
+++ b/switchboard-sfu/Cargo.toml
@@ -12,7 +12,6 @@ default-run = "switchboard"
 default = ["simulcast", "audiolevel"]
 simulcast = []
 audiolevel = []
-#p2p = ["libp2p"]
 
 [dependencies]
 anyhow = "1"
@@ -34,8 +33,7 @@ enclose = "1.1.8"
 async-trait = "0.1.53"
 uuid = { version = "1.0.0", features = ["v4"]}
 
-#webrtc = "0.4.0"
-webrtc = { git = "https://github.com/webrtc-rs/webrtc", branch = "master" }
+webrtc = "0.5.1"
 
 #libp2p experiment
 #libp2p = { version = "0.40.0", features = ["tcp-tokio"], optional = true}
@@ -43,10 +41,6 @@ webrtc = { git = "https://github.com/webrtc-rs/webrtc", branch = "master" }
 [[bin]]
 name = "switchboard"
 path = "bin/main.rs"
-
-#[[bin]]
-#name = "p2p"
-#path = "bin/p2p.rs"
 
 
 

--- a/switchboard-sfu/src/sfu/session.rs
+++ b/switchboard-sfu/src/sfu/session.rs
@@ -22,9 +22,12 @@ pub type WriteStream = mpsc::Sender<SessionEvent>;
 #[async_trait]
 pub trait Session {
     fn new(id: Id) -> SessionHandle<Self>;
+    fn id(&self) -> Id;
+    async fn active(&self) -> bool;
+    fn write_channel(&self) -> WriteStream;
+
     async fn add_peer(&self, id: peer::Id, peer: Arc<peer::Peer>) -> Result<()>;
     async fn remove_peer(&self, id: peer::Id) -> Result<()>;
-    fn write_channel(&self) -> WriteStream;
 }
 
 pub enum SessionEvent {
@@ -33,7 +36,7 @@ pub enum SessionEvent {
 }
 
 pub struct LocalSession {
-    id: Id,
+    pub id: Id,
     peers: Arc<Mutex<HashMap<peer::Id, Arc<peer::Peer>>>>,
     routers: Arc<Mutex<HashMap<String, MediaTrackRouterHandle>>>,
     tx: WriteStream,
@@ -45,16 +48,25 @@ impl Session for LocalSession {
         let (tx, rx) = mpsc::channel(16);
 
         let handle = Arc::new(LocalSession {
-            id: id,
+            id,
             peers: Arc::new(Mutex::new(HashMap::new())),
             routers: Arc::new(Mutex::new(HashMap::new())),
-            tx: tx,
+            tx,
         });
 
         tokio::spawn(enc!((handle) async move { LocalSession::event_loop(handle, rx).await } ));
 
         debug!("LocalSession(id={}) started", handle.id);
         handle
+    }
+
+    fn id(&self) -> Id {
+        self.id.clone()
+    }
+
+    async fn active(&self) -> bool {
+        let peers = self.peers.lock().await;
+        peers.len() > 0
     }
 
     fn write_channel(&self) -> WriteStream {

--- a/switchboard-sfu/src/sfu/session.rs
+++ b/switchboard-sfu/src/sfu/session.rs
@@ -108,6 +108,7 @@ impl LocalSession {
     }
 
     async fn remove_router(&self, router_id: String) {
+        let _ = self.peers.lock().await;
         let mut routers = self.routers.lock().await;
         let _router = routers.remove(&router_id);
     }

--- a/switchboard-sfu/src/signal/server.rs
+++ b/switchboard-sfu/src/signal/server.rs
@@ -146,6 +146,8 @@ pub async fn event_loop<C, S>(
                 .remove_peer(peer.id)
                 .await
                 .expect("error removing peer");
+
+            coordinator.cleanup_session(session.id()).await;
         }
     }
 }


### PR DESCRIPTION
- Cleaned up a few issues with signal hooks causing panics when last peer connection is closed
- Drop LocalSession after last peer leaves (in LocalCoordinator)

fixes #4 
