### PR TITLE
Client Presence Metadata API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2070,6 +2070,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93bbc61e655a4833cf400d0d15bf3649313422fa7572886ad6dab16d79886365"
 dependencies = [
  "getrandom 0.2.6",
+ "serde",
 ]
 
 [[package]]

--- a/switchboard-sfu/Cargo.toml
+++ b/switchboard-sfu/Cargo.toml
@@ -31,7 +31,7 @@ async-mutex = "1.4.0"
 futures-channel = "0.3.21"
 enclose = "1.1.8"
 async-trait = "0.1.53"
-uuid = { version = "1.0.0", features = ["v4"]}
+uuid = { version = "1.0.0", features = ["v4", "serde"]}
 
 webrtc = "0.5.1"
 

--- a/switchboard-sfu/src/sfu/peer.rs
+++ b/switchboard-sfu/src/sfu/peer.rs
@@ -50,6 +50,8 @@ pub struct Peer {
     pub sub_rtcp_writer: RtcpWriter,
 
     pub sub_pending_candidates: Arc<Mutex<Vec<RTCIceCandidateInit>>>,
+
+    pub signal_tx: signal::WriteStream,
 }
 
 impl Peer {
@@ -70,6 +72,7 @@ impl Peer {
             subscriber,
             sub_rtcp_writer,
             sub_pending_candidates: Arc::new(Mutex::new(vec![])),
+            signal_tx: signal_tx.clone(),
         };
 
         peer.setup_signal_hooks(signal_tx, session_tx).await;

--- a/switchboard-sfu/src/signal/server.rs
+++ b/switchboard-sfu/src/signal/server.rs
@@ -134,6 +134,16 @@ pub async fn event_loop<C, S>(
                     error!("peer has not joined session yet");
                 }
             },
+            signal::Event::Presence(presence) => match &peer {
+                Some(peer) => {
+                    if let Some(ref mut session) = joined_session.as_mut() {
+                        session.presence_set(peer.id, presence.meta).await;
+                    }
+                }
+                None => {
+                    error!("peer has not joined session yet");
+                }
+            },
             _ => {}
         }
     }

--- a/switchboard-sfu/src/signal/signal.rs
+++ b/switchboard-sfu/src/signal/signal.rs
@@ -134,9 +134,12 @@ pub async fn handle_messages(
                         sig_read_tx.unbounded_send(Ok(Event::PublisherOffer(tx, o))).expect("error forwarding signal message");
                     },
                     "presence_set" => {
-                        let p: Presence =
+                        let meta: serde_json::Value =
                             serde_json::from_value(Value::Object(r.params)).expect("error parsing");
-                        sig_read_tx.unbounded_send(Ok(Event::Presence(p))).expect("error forwarding signal message");
+                        sig_read_tx.unbounded_send(Ok(Event::Presence(Presence{
+                            revision: 0,
+                            meta: meta,
+                        }))).expect("error forwarding signal message");
                     }
 
                     _ => {}


### PR DESCRIPTION
Adds presence_set call and presence notification (compatible with https://github.com/cryptagon/ion-cluster api)

fixes #5 