### PR TITLE
Simulcast Support

### DIFF
--- a/examples/pubsubtest/main.js
+++ b/examples/pubsubtest/main.js
@@ -63,6 +63,7 @@ const start = () => {
     resolution: "hd",
     audio: true,
     codec: params.has("codec") ? params.get("codec") : "VP8",
+    simulcast: true,
   })
     .then((media) => {
       localStream = media;

--- a/switchboard-sfu/src/sfu/peer.rs
+++ b/switchboard-sfu/src/sfu/peer.rs
@@ -220,6 +220,7 @@ impl Peer {
                     if let (Some(track), Some(receiver)) = (track,receiver) {
                         tokio::spawn(async move {
                             let id = track.id().await;
+
                             let (media_track_router, closed) = MediaTrackRouter::new(track, receiver, pub_rtcp_tx).await;
                             session_tx.send(SessionEvent::TrackPublished(media_track_router.clone())).await.expect("error sending track router to session");
                             let _ = closed.await;

--- a/switchboard-sfu/src/sfu/peer.rs
+++ b/switchboard-sfu/src/sfu/peer.rs
@@ -4,6 +4,7 @@ use enclose::enc;
 use futures::{SinkExt, StreamExt};
 use futures_channel::mpsc;
 use log::*;
+use std::collections::HashMap;
 use std::sync::Arc;
 use uuid::Uuid;
 use webrtc::api::setting_engine::SettingEngine;
@@ -212,16 +213,31 @@ impl Peer {
             .await;
 
         let pub_rtcp_tx = self.pub_rtcp_writer.clone();
+        let published_routers = Arc::new(Mutex::new(HashMap::new()));
         self.publisher
-            .on_track(Box::new(enc!( (session_tx) {
+            .on_track(Box::new(enc!( (session_tx, published_routers) {
                 move |track: Option<Arc<TrackRemote>>, receiver: Option<Arc<RTCRtpReceiver>>| {
-                    Box::pin( enc!( (mut session_tx, pub_rtcp_tx) async move {
+                    Box::pin( enc!( (mut session_tx, pub_rtcp_tx, mut published_routers) async move {
 
                     if let (Some(track), Some(receiver)) = (track,receiver) {
                         tokio::spawn(async move {
                             let id = track.id().await;
 
-                            let (media_track_router, closed) = MediaTrackRouter::new(track, receiver, pub_rtcp_tx).await;
+                            let (media_track_router, closed) = {
+                                let mut routers = published_routers.lock().await;
+                                let router = match routers.get(&id) {
+                                    None => {
+                                        let r = MediaTrackRouter::new(track.ssrc(), id.clone(), pub_rtcp_tx).await; 
+                                        routers.insert(id.clone(), r.clone());
+                                        r
+                                    },
+                                    Some(r) => r.clone(),
+                                };
+
+                                let closed = { router.lock().await.add_layer(track,receiver).await };
+                                (router.clone(), closed)
+                            };
+
                             session_tx.send(SessionEvent::TrackPublished(media_track_router.clone())).await.expect("error sending track router to session");
                             let _ = closed.await;
                             session_tx.send(SessionEvent::TrackRemoved(id)).await.expect("error sending track removed");

--- a/switchboard-sfu/src/sfu/routing/mod.rs
+++ b/switchboard-sfu/src/sfu/routing/mod.rs
@@ -6,6 +6,7 @@ pub use subscriber::*;
 
 // Layer
 // Used by router & subscriber to determine which video stream to send
+#[derive(Clone)]
 pub enum Layer {
     // Mute Stream
     None,

--- a/switchboard-sfu/src/sfu/routing/mod.rs
+++ b/switchboard-sfu/src/sfu/routing/mod.rs
@@ -3,3 +3,14 @@ mod subscriber;
 
 pub use router::*;
 pub use subscriber::*;
+
+// Layer
+// Used by router & subscriber to determine which video stream to send
+pub enum Layer {
+    // Mute Stream
+    None,
+    // Single video stream
+    Unicast,
+    // Simulcast layer w/RID
+    Rid(String),
+}

--- a/switchboard-sfu/src/sfu/routing/mod.rs
+++ b/switchboard-sfu/src/sfu/routing/mod.rs
@@ -6,12 +6,20 @@ pub use subscriber::*;
 
 // Layer
 // Used by router & subscriber to determine which video stream to send
-#[derive(Clone)]
+#[derive(Clone, Eq, PartialEq, Hash, Debug)]
 pub enum Layer {
-    // Mute Stream
     None,
     // Single video stream
     Unicast,
     // Simulcast layer w/RID
     Rid(String),
+}
+
+impl Layer {
+    pub fn from(rid: &str) -> Layer {
+        match rid {
+            "" => Layer::Unicast,
+            layer => Layer::Rid(layer.to_owned()),
+        }
+    }
 }

--- a/switchboard-sfu/src/sfu/routing/router.rs
+++ b/switchboard-sfu/src/sfu/routing/router.rs
@@ -3,6 +3,7 @@ use enclose::enc;
 use futures::StreamExt;
 use futures_channel::{mpsc, oneshot};
 use log::*;
+use std::collections::HashMap;
 use std::sync::Arc;
 use tokio::sync::broadcast;
 use webrtc::rtcp::payload_feedbacks::picture_loss_indication::PictureLossIndication;
@@ -20,7 +21,7 @@ pub type MediaTrackRouterHandle = Arc<Mutex<MediaTrackRouter>>;
 /// write the track to multiple other peer connections
 pub struct MediaTrackRouter {
     pub id: Id,
-    track_remote: Arc<TrackRemote>,
+    track_remotes: HashMap<Layer, Arc<TrackRemote>>,
 
     event_tx: mpsc::Sender<MediaTrackSubscriberEvent>,
     packet_sender: broadcast::Sender<rtp::packet::Packet>,
@@ -50,7 +51,7 @@ impl MediaTrackRouter {
         (
             Arc::new(Mutex::new(MediaTrackRouter {
                 id: track_remote.id().await,
-                track_remote,
+                track_remote: map![],
                 packet_sender: pkt_tx,
                 _rtp_receiver: rtp_receiver,
                 event_tx: evt_tx,
@@ -58,6 +59,8 @@ impl MediaTrackRouter {
             closed_rx,
         )
     }
+
+    pub async fn add_layer(&mut self, layer: Layer, track: Arc<TrackRemote>) {}
 
     pub async fn add_subscriber(&self) -> MediaTrackSubscriber {
         trace!("MediaTrackRouter adding new subscriber");

--- a/switchboard-sfu/src/sfu/session.rs
+++ b/switchboard-sfu/src/sfu/session.rs
@@ -8,6 +8,7 @@ use log::*;
 use std::collections::HashMap;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
+use webrtc::track::track_remote::TrackRemote;
 
 use crate::sfu::peer;
 use crate::sfu::routing::MediaTrackRouterHandle;
@@ -171,21 +172,25 @@ impl LocalSession {
         let _router = routers.remove(&router_id);
     }
 
-    async fn subscribe_all_peers_to_router(&self, router: &MediaTrackRouterHandle) {
+    async fn subscribe_all_peers_to_router(&self, router: &MediaTrackRouterHandle) -> Result<()> {
         let mut peers = self.peers.lock().await;
 
         for (_, peer) in &mut *peers {
-            let subscriber = { router.lock().await.add_subscriber().await };
+            let subscriber = { router.lock().await.add_subscriber().await? };
             peer.add_media_track_subscriber(subscriber).await;
         }
+
+        Ok(())
     }
 
-    async fn subscribe_peer_to_all_routers(&self, peer: &Arc<peer::Peer>) {
+    async fn subscribe_peer_to_all_routers(&self, peer: &Arc<peer::Peer>) -> Result<()> {
         let mut routers = self.routers.lock().await;
 
         for (_, router) in &mut *routers {
-            let subscriber = { router.lock().await.add_subscriber().await };
+            let subscriber = { router.lock().await.add_subscriber().await? };
             peer.add_media_track_subscriber(subscriber).await;
         }
+
+        Ok(())
     }
 }


### PR DESCRIPTION
- [x] Add layer support to MediaTrackRouter and Layer Selection logic in MediaTrackSubscriber
- [ ] Add API for selecting current layer in MediaTrackSubscriber
- [ ] Add Keyframe Detection in MediaTrackRouter & Re-Sync to keyframe on layer change in MediaTrackSubscriber (#7)
- [ ] Add automatic fallback to lower layer in MediaTrackSubscriber


fixes #11 